### PR TITLE
Post-parsing utility methods

### DIFF
--- a/lib/Sparsely.js
+++ b/lib/Sparsely.js
@@ -88,13 +88,23 @@ class Sparsely {
 
   /**
    * Returns true if the option with, 'name'
-   * has been parsed:
+   * has been parsed.
    * 
-   * @param {string} name the name of the option to check 
+   * @param {string} name the name of the option to check for
    * @returns {boolean}
    */
   isParsedOption(name) {
     return this.#parsedOptions.filter(option => option.name == name).length > 0;
+  }
+
+  /**
+   * Returns true if 'argument' has been parsed.
+   * 
+   * @param {string} argument the argument to check for 
+   * @returns {boolean}
+   */
+  isParsedArg(argument) {
+    return this.#parsedArgs.filter(arg => arg == argument).length > 0;
   }
 
   report() {

--- a/lib/Sparsely.js
+++ b/lib/Sparsely.js
@@ -86,6 +86,17 @@ class Sparsely {
     this.#options.push(option);
   }
 
+  /**
+   * Returns true if the option with, 'name'
+   * has been parsed:
+   * 
+   * @param {string} name the name of the option to check 
+   * @returns {boolean}
+   */
+  isParsedOption(name) {
+    return this.#parsedOptions.filter(option => option.name == name).length > 0;
+  }
+
   report() {
     console.log(`Errors: ${this.#errors}`);
     console.log('Options:');

--- a/lib/Sparsely.js
+++ b/lib/Sparsely.js
@@ -83,6 +83,12 @@ class Sparsely {
     if (typeof option.maxArgs !== 'number') {
       throw new Error('option.maxArgs must be of type number');
     }
+    if (this.#isValidOption(option.name)) {
+      throw new Error(`an option with the name '${option.name}' has already been registered`);
+    }
+    if (this.#isValidOption(option.shorthand)) {
+      throw new Error(`an option with the shorthand '${option.shorthand}' has already been registered`);
+    }
     this.#options.push(option);
   }
 

--- a/test/Sparsely.test.js
+++ b/test/Sparsely.test.js
@@ -527,7 +527,7 @@ describe('Sparse (with test options)', () => {
   // the isParsedOption method indicates
   // whether an option has been parsed
   // or not:
-  describe('argv = ["-A -B"]', () => {
+  describe('argv = ["-A, -B"]', () => {
     const parser = new Sparsely();
 
     testOptions.forEach(option => {
@@ -537,27 +537,15 @@ describe('Sparse (with test options)', () => {
     const argv = [ '-A', '-B' ];
     parser.exec(argv);
 
-    describe('errors', () => {
-      const expected = 1;
-      it(`should return an array of length ${expected}`, () => {
-        const errors = parser.errors;
-        expect(errors).to.have.lengthOf(expected);
+    describe('isParsedOption', () => {
+      it('should return true with an argument of "option-A"', () => {
+        const result = parser.isParsedOption('option-A');
+        expect(result).to.be.true;
       });
-    });
 
-    describe('parsedArgs', () => {
-      const expected = 0;
-      it(`should return an array of length ${expected}`, () => {
-        const parsedArgs = parser.parsedArgs;
-        expect(parsedArgs).to.have.lengthOf(expected);
-      });
-    });
-
-    describe('parsedOptions', () => {
-      const expected = 1;
-      it(`should return an array of length ${expected}`, () => {
-        const parsedOptions = parser.parsedOptions;
-        expect(parsedOptions).to.have.lengthOf(expected);
+      it('should return false with an argument of "option-B"', () => {
+        const result = parser.isParsedOption('option-B');
+        expect(result).to.be.false;
       });
     });
   });

--- a/test/Sparsely.test.js
+++ b/test/Sparsely.test.js
@@ -549,4 +549,31 @@ describe('Sparse (with test options)', () => {
       });
     });
   });
+
+  // This suite tests to ensure that
+  // the isParsedOption method indicates
+  // whether an option has been parsed
+  // or not:
+  describe('argv = ["arg1"]', () => {
+    const parser = new Sparsely();
+
+    testOptions.forEach(option => {
+      parser.addOption(option);
+    });
+
+    const argv = [ 'arg1' ];
+    parser.exec(argv);
+
+    describe('isParsedArg', () => {
+      it('should return true with an argument of "arg1"', () => {
+        const result = parser.isParsedArg('arg1');
+        expect(result).to.be.true;
+      });
+
+      it('should return false with an argument of "arg2"', () => {
+        const result = parser.isParsedArg('arg2');
+        expect(result).to.be.false;
+      });
+    });
+  });
 }); 

--- a/test/Sparsely.test.js
+++ b/test/Sparsely.test.js
@@ -522,4 +522,43 @@ describe('Sparse (with test options)', () => {
       });
     });
   });
+
+  // This suite tests to ensure that
+  // the isParsedOption method indicates
+  // whether an option has been parsed
+  // or not:
+  describe('argv = ["-A -B"]', () => {
+    const parser = new Sparsely();
+
+    testOptions.forEach(option => {
+      parser.addOption(option);
+    });
+
+    const argv = [ '-A', '-B' ];
+    parser.exec(argv);
+
+    describe('errors', () => {
+      const expected = 1;
+      it(`should return an array of length ${expected}`, () => {
+        const errors = parser.errors;
+        expect(errors).to.have.lengthOf(expected);
+      });
+    });
+
+    describe('parsedArgs', () => {
+      const expected = 0;
+      it(`should return an array of length ${expected}`, () => {
+        const parsedArgs = parser.parsedArgs;
+        expect(parsedArgs).to.have.lengthOf(expected);
+      });
+    });
+
+    describe('parsedOptions', () => {
+      const expected = 1;
+      it(`should return an array of length ${expected}`, () => {
+        const parsedOptions = parser.parsedOptions;
+        expect(parsedOptions).to.have.lengthOf(expected);
+      });
+    });
+  });
 }); 

--- a/test/Sparsely.test.js
+++ b/test/Sparsely.test.js
@@ -527,7 +527,7 @@ describe('Sparse (with test options)', () => {
   // the isParsedOption method indicates
   // whether an option has been parsed
   // or not:
-  describe('argv = ["-A, -B"]', () => {
+  describe('argv = ["-A", "-B"]', () => {
     const parser = new Sparsely();
 
     testOptions.forEach(option => {


### PR DESCRIPTION
Add post-parsing utility methods and ensure that only one option can be added with a given name or shorthand.